### PR TITLE
bug fix: eth_blockNumber

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -145,7 +145,7 @@ func (p *Server) Example(w http.ResponseWriter, r *http.Request) {
 	case "clique_getVotersAtHash":
 		do(hexHash)
 	case "eth_blockNumber":
-		do(hexNumOrLatest)
+		do()
 	case "eth_chainId":
 		do()
 	case "eth_gasPrice":


### PR DESCRIPTION
`eth_blockNumber` doesn't take any parameters, but the current implementation adds a parameter `latest`, causing the following rpc error.

```
{
  "jsonrpc": "2.0",
  "id": "1",
  "error": {
    "code": -32602,
    "message": "too many arguments, want at most 0"
  }
}
```